### PR TITLE
Link to the Vulkan loader by default on macOS

### DIFF
--- a/src/vulkan.nim
+++ b/src/vulkan.nim
@@ -14,7 +14,7 @@ when not defined(vkCustomLoader):
   when defined(windows):
     const vkDLL = "vulkan-1.dll"
   elif defined(macosx):
-    if defined(libMoltenVK):
+    when defined(libMoltenVK):
       const vkDLL = "libMoltenVK.dylib"
     else:
       const vkDLL = "libvulkan.1.dylib"

--- a/src/vulkan.nim
+++ b/src/vulkan.nim
@@ -14,7 +14,10 @@ when not defined(vkCustomLoader):
   when defined(windows):
     const vkDLL = "vulkan-1.dll"
   elif defined(macosx):
-    const vkDLL = "libMoltenVK.dylib"
+    if defined(libMoltenVK):
+      const vkDLL = "libMoltenVK.dylib"
+    else:
+      const vkDLL = "libvulkan.1.dylib"
   else:
     const vkDLL = "libvulkan.so.1"
 

--- a/tools/utils.nim
+++ b/tools/utils.nim
@@ -17,7 +17,7 @@ when not defined(vkCustomLoader):
   when defined(windows):
     const vkDLL = "vulkan-1.dll"
   elif defined(macosx):
-    if defined(libMoltenVK):
+    when defined(libMoltenVK):
       const vkDLL = "libMoltenVK.dylib"
     else:
       const vkDLL = "libvulkan.1.dylib"

--- a/tools/utils.nim
+++ b/tools/utils.nim
@@ -17,7 +17,10 @@ when not defined(vkCustomLoader):
   when defined(windows):
     const vkDLL = "vulkan-1.dll"
   elif defined(macosx):
-    const vkDLL = "libMoltenVK.dylib"
+    if defined(libMoltenVK):
+      const vkDLL = "libMoltenVK.dylib"
+    else:
+      const vkDLL = "libvulkan.1.dylib"
   else:
     const vkDLL = "libvulkan.so.1"
 


### PR DESCRIPTION
This will make the default library that gets linked to on macOS be the Vulkan loader (`libvulkan.1.dylib`). And linking directly to MoltenVK (`libMoltenVK.dylib`) will still be available, but will require using the compiler option `-d:libMoltenVK`.

Linking directly to MoltenVK bypasses loading any layers, so when I query which layers are available with vkEnumerateInstanceLayerProperties(), it only lists "MoltenVK". By instead linking to the Vulkan loader, it will load any available layers and then dynamically link to MoltenVK, making it so that when I query which layers are available, I get the expected layers installed with the Vulkan SDK (VK_LAYER_KHRONOS_validation, etc.). I would think that this would be the expected default behavior by most users.

Let me know what you think, and if there is anything you want me to change about the PR. I wasn't sure what name to use for the MoltenVK compile-time symbol, but I thought `libMoltenVK` seemed logical, but let me know if you think a different name would be better.